### PR TITLE
Fix unknown host

### DIFF
--- a/src/dmarc2logstash.py
+++ b/src/dmarc2logstash.py
@@ -174,12 +174,17 @@ def parse(jsonOutputFile, xml, subject):
 
 def lookupHostFromIp(ip):
   host = ip
-  hosts = socket.gethostbyaddr(ip)
-  if len(hosts) > 0:
-    host = hosts[0]
-    segments = host.split('.')
-    if len(segments) > 2:
-      host = segments[-2] + "." + segments[-1]
+  try:
+    hosts = socket.gethostbyaddr(ip)
+    if len(hosts) > 0:
+      host = hosts[0]
+      segments = host.split('.')
+      if len(segments) > 2:
+        host = segments[-2] + "." + segments[-1]
+  except socket.herror:
+    pass
+  except Exception as e:
+    print(f"An error occurred: {e}")
 
   return host
 

--- a/src/dmarc2logstash.py
+++ b/src/dmarc2logstash.py
@@ -184,7 +184,7 @@ def lookupHostFromIp(ip):
   except socket.herror:
     pass
   except Exception as e:
-    print(f"An error occurred: {e}")
+    log.warning(f"Unable to lookup hostname for IP; ip={ip}; error={e}")
 
   return host
 


### PR DESCRIPTION
`socket.gethostbyaddr` function triggers an _"[Errno 1] Unknown host"_ exception if the provided IP address cannot be resolved.

In example:

```bash
python3 -c 'import socket; socket.gethostbyaddr("10.1.1.1")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
socket.herror: [Errno 1] Unknown host
```
The proposed fix allows the execution to continue.